### PR TITLE
mm-camera-interface: Retry in case of timeouts

### DIFF
--- a/camera/QCamera2/stack/mm-camera-interface/src/mm_camera.c
+++ b/camera/QCamera2/stack/mm-camera-interface/src/mm_camera.c
@@ -252,14 +252,15 @@ int32_t mm_camera_open(mm_camera_obj_t *my_obj)
 
     do{
         n_try--;
+        errno = 0;
         my_obj->ctrl_fd = open(dev_name, O_RDWR | O_NONBLOCK);
         CDBG("%s:  ctrl_fd = %d, errno == %d", __func__, my_obj->ctrl_fd, errno);
-        if((my_obj->ctrl_fd >= 0) || (errno != EIO) || (n_try <= 0 )) {
+        if((my_obj->ctrl_fd >= 0) || (errno != EIO && errno != ETIMEDOUT) || (n_try <= 0 )) {
             CDBG_HIGH("%s:  opened, break out while loop", __func__);
             break;
         }
-        CDBG_HIGH("%s:failed with I/O error retrying after %d milli-seconds",
-             __func__, sleep_msec);
+        ALOGE("%s:Failed with %s error, retrying after %d milli-seconds",
+             __func__, strerror(errno), sleep_msec);
         usleep(sleep_msec * 1000);
     }while (n_try > 0);
 


### PR DESCRIPTION
Incase of delayed daemon start there is possibility of
timeout, HAL should re-attempt in those cases to allow
time for daemon to start.

Bug: 19565773
Change-Id: I1920fb32652e944ca599efef7801045b60c42ca8
